### PR TITLE
Initialize React Vite app with routing and Tailwind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-# TestDriveCodex

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Telemed</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "telemed",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.16.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.27",
+    "tailwindcss": "^3.3.3",
+    "vite": "^4.3.9"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,22 @@
+import { Routes, Route } from 'react-router-dom'
+import Navbar from './components/Navbar'
+import Login from './pages/Login'
+import PatientDashboard from './pages/PatientDashboard'
+import DoctorDashboard from './pages/DoctorDashboard'
+import Chat from './pages/Chat'
+
+function App() {
+  return (
+    <>
+      <Navbar />
+      <Routes>
+        <Route path="/" element={<Login />} />
+        <Route path="/patient-dashboard" element={<PatientDashboard />} />
+        <Route path="/doctor-dashboard" element={<DoctorDashboard />} />
+        <Route path="/chat" element={<Chat />} />
+      </Routes>
+    </>
+  )
+}
+
+export default App

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,0 +1,42 @@
+import { Link } from 'react-router-dom'
+import { useState } from 'react'
+
+export default function Navbar() {
+  const [open, setOpen] = useState(false)
+  const toggle = () => setOpen(!open)
+
+  return (
+    <nav className="bg-blue-600 text-white">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between h-16">
+          <div className="flex items-center">
+            <Link to="/" className="font-bold">Telemed</Link>
+          </div>
+          <div className="hidden md:block">
+            <div className="ml-10 flex items-baseline space-x-4">
+              <Link to="/" className="px-3 py-2 rounded-md hover:bg-blue-700">Login</Link>
+              <Link to="/patient-dashboard" className="px-3 py-2 rounded-md hover:bg-blue-700">Patient</Link>
+              <Link to="/doctor-dashboard" className="px-3 py-2 rounded-md hover:bg-blue-700">Doctor</Link>
+              <Link to="/chat" className="px-3 py-2 rounded-md hover:bg-blue-700">Chat</Link>
+            </div>
+          </div>
+          <div className="md:hidden">
+            <button onClick={toggle} className="p-2 rounded-md hover:bg-blue-700 focus:outline-none">
+              <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16M4 18h16" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+      {open && (
+        <div className="md:hidden px-2 pt-2 pb-3 space-y-1">
+          <Link to="/" onClick={() => setOpen(false)} className="block px-3 py-2 rounded-md hover:bg-blue-700">Login</Link>
+          <Link to="/patient-dashboard" onClick={() => setOpen(false)} className="block px-3 py-2 rounded-md hover:bg-blue-700">Patient</Link>
+          <Link to="/doctor-dashboard" onClick={() => setOpen(false)} className="block px-3 py-2 rounded-md hover:bg-blue-700">Doctor</Link>
+          <Link to="/chat" onClick={() => setOpen(false)} className="block px-3 py-2 rounded-md hover:bg-blue-700">Chat</Link>
+        </div>
+      )}
+    </nav>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+)

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -1,0 +1,7 @@
+export default function Chat() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">Chat</h1>
+    </div>
+  )
+}

--- a/src/pages/DoctorDashboard.jsx
+++ b/src/pages/DoctorDashboard.jsx
@@ -1,0 +1,7 @@
+export default function DoctorDashboard() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">Doctor Dashboard</h1>
+    </div>
+  )
+}

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,0 +1,7 @@
+export default function Login() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">Login</h1>
+    </div>
+  )
+}

--- a/src/pages/PatientDashboard.jsx
+++ b/src/pages/PatientDashboard.jsx
@@ -1,0 +1,7 @@
+export default function PatientDashboard() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">Patient Dashboard</h1>
+    </div>
+  )
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./index.html", "./src/**/*.{js,jsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
## Summary
- scaffold basic React app with Vite and Tailwind configuration
- add Login, PatientDashboard, DoctorDashboard, and Chat pages
- set up React Router and responsive navigation menu
- adjust index.html to use relative script path for local file access

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@vitejs%2fplugin-react)*
- `npm test`
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896c96b3a1c83229e4f52b832719d25